### PR TITLE
Add card component and design utilities

### DIFF
--- a/css/base/text-colors.css
+++ b/css/base/text-colors.css
@@ -1,101 +1,102 @@
 @import url(colors.css);
 /* White */
 .text-color-white{
-    background-color: var(--white);
+    color: var(--white);
 }
 
 /* Blacks Backgrounds */
 .text-color-black-50{
-    background-color: var(--black-50);
+    color: var(--black-50);
 }
 .text-color-black-100{
-    background-color: var(--black-100);
+    color: var(--black-100);
 }
 .text-color-black-200{
-    background-color: var(--black-200);
+    color: var(--black-200);
 }
 .text-color-black-300{
-    background-color: var(--black-300);
+    color: var(--black-300);
 }
 .text-color-black-400{
-    background-color: var(--black-400);
+    color: var(--black-400);
 }
 .text-color-black-500{
-    background-color: var(--black-500);
+    color: var(--black-500);
 }
 .text-color-black-600{
-    background-color: var(--black-600);
+    color: var(--black-600);
 }
 .text-color-black-700{
-    background-color: var(--black-700);
+    color: var(--black-700);
 }
 .text-color-black-800{
-    background-color: var(--black-800);
+    color: var(--black-800);
 }
 .text-color-black-900{
-    background-color: var(--black-900);
+    color: var(--black-900);
 }
 
 /* Blues Backgrounds */
 .text-color-blue-50{
-    background-color: var(--blue-50);
+    color: var(--blue-50);
 }
 .text-color-blue-100{
-    background-color: var(--blue-100);
+    color: var(--blue-100);
 }
 .text-color-blue-200{
-    background-color: var(--blue-200);
+    color: var(--blue-200);
 }
 .text-color-blue-300{
-    background-color: var(--blue-300);
+    color: var(--blue-300);
 }
 .text-color-blue-400{
-    background-color: var(--blue-400);
+    color: var(--blue-400);
 }
 .text-color-blue-500{
-    background-color: var(--blue-500);
+    color: var(--blue-500);
 }
 .text-color-blue-600{
-    background-color: var(--blue-600);
+    color: var(--blue-600);
 }
 .text-color-blue-700{
-    background-color: var(--blue-700);
+    color: var(--blue-700);
 }
 .text-color-blue-800{
-    background-color: var(--blue-800);
+    color: var(--blue-800);
 }
 .text-color-blue-900{
-    background-color: var(--blue-900);
+    color: var(--blue-900);
 }
 
 /* greens Backgrounds */
 .text-color-green-50{
-    background-color: var(--green-50);
+    color: var(--green-50);
 }
 .text-color-green-100{
-    background-color: var(--green-100);
+    color: var(--green-100);
 }
 .text-color-green-200{
-    background-color: var(--green-200);
+    color: var(--green-200);
 }
 .text-color-green-300{
-    background-color: var(--green-300);
+    color: var(--green-300);
 }
 .text-color-green-400{
-    background-color: var(--green-400);
+    color: var(--green-400);
 }
 .text-color-green-500{
-    background-color: var(--green-500);
+    color: var(--green-500);
 }
 .text-color-green-600{
-    background-color: var(--green-600);
+    color: var(--green-600);
 }
 .text-color-green-700{
-    background-color: var(--green-700);
+    color: var(--green-700);
 }
 .text-color-green-800{
-    background-color: var(--green-800);
+    color: var(--green-800);
 }
 .text-color-green-900{
-    background-color: var(--green-900);
+    color: var(--green-900);
 }
+

--- a/css/base/utilities.css
+++ b/css/base/utilities.css
@@ -1,0 +1,10 @@
+/* Margin utilities */
+.margin-small { margin: var(--space-sm); }
+.margin-medium { margin: var(--space-md); }
+.margin-large { margin: var(--space-lg); }
+
+/* Padding utilities */
+.padding-small { padding: var(--space-sm); }
+.padding-medium { padding: var(--space-md); }
+.padding-large { padding: var(--space-lg); }
+

--- a/css/base/variables.css
+++ b/css/base/variables.css
@@ -1,0 +1,18 @@
+:root {
+  /* Spacing */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+
+  /* Border radius */
+  --radius-sm: 4px;
+  --radius-base: 8px;
+  --radius-lg: 16px;
+
+  /* Font families */
+  --font-base: 'Open Sans', sans-serif;
+  --font-title: 'Montserrat', sans-serif;
+}
+

--- a/css/molecules/card.css
+++ b/css/molecules/card.css
@@ -1,0 +1,31 @@
+/* molecules/_card.css */
+.card {
+  background-color: var(--white);
+  border: 1px solid var(--black-200);
+  border-radius: var(--radius-base);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.card-header,
+.card-footer {
+  padding: var(--space-md);
+  background-color: var(--black-50);
+}
+
+.card-body {
+  padding: var(--space-md);
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+
+.card-text {
+  margin-top: var(--space-sm);
+}
+

--- a/css/styles.css
+++ b/css/styles.css
@@ -18,6 +18,7 @@
 /* Molecules */
 @import url(molecules/blockquote.css);
 @import url(molecules/sections.css);
+@import url(molecules/card.css);
 
 /* Organisms */
 @import url(organisms/main.css);

--- a/index.html
+++ b/index.html
@@ -243,6 +243,50 @@
               </div>
          </section>
         <!-- En Colors -->
+        <section>
+            <h3>Cards</h3>
+            <div class="grid-container">
+                <div class="col" data-col-span="4">
+                    <div class="card margin-medium">
+                        <div class="card-header">
+                            <h4 class="card-title">Título 1</h4>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text">Ejemplo de texto en la tarjeta.</p>
+                        </div>
+                        <div class="card-footer">
+                            <button>Acción</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="col" data-col-span="4">
+                    <div class="card margin-medium">
+                        <div class="card-header">
+                            <h4 class="card-title">Título 2</h4>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text">Otro contenido en la tarjeta.</p>
+                        </div>
+                        <div class="card-footer">
+                            <button>Acción</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="col" data-col-span="4">
+                    <div class="card margin-medium">
+                        <div class="card-header">
+                            <h4 class="card-title">Título 3</h4>
+                        </div>
+                        <div class="card-body">
+                            <p class="card-text">Más contenido de ejemplo.</p>
+                        </div>
+                        <div class="card-footer">
+                            <button>Acción</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
 
     </main>
     <script type="module" src="js/main.js"></script>


### PR DESCRIPTION
## Summary
- define base design variables
- create margin and padding utilities
- fix text color classes to use `color` instead of `background-color`
- add card molecule with example markup
- import new styles and update example page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6871a587fb0083228f98655021c714c7