### PR TITLE
Implement atomic design structure with demo pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ AtomOS es un sistema de diseño modular basado en Atomic Design. Esta versión u
 
 ## Uso
 Abre las páginas dentro de `pages/` o usa las plantillas como base para nuevos proyectos.
+
+## Despliegue en GitHub Pages
+1. Haz un fork del repositorio o clónalo en tu cuenta.
+2. En la configuración del repositorio, habilita **GitHub Pages** desde la rama principal.
+3. Asegúrate de que las rutas son relativas (ya incluidas en este proyecto).
+4. Al guardar los cambios, tu sitio estará disponible en `https://<usuario>.github.io/<repositorio>/`.
+

--- a/atoms/button/button.html
+++ b/atoms/button/button.html
@@ -1,1 +1,31 @@
-<button class="btn" data-role="button">Click me</button>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Botón</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <h1>Botón</h1>
+    <button class="btn" data-role="button">Click me</button>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+  <script src="button.js"></script>
+</body>
+</html>
+

--- a/atoms/headings/headings.html
+++ b/atoms/headings/headings.html
@@ -1,6 +1,31 @@
-<h1 class="heading" data-level="1">Heading 1</h1>
-<h2 class="heading" data-level="2">Heading 2</h2>
-<h3 class="heading" data-level="3">Heading 3</h3>
-<h4 class="heading" data-level="4">Heading 4</h4>
-<h5 class="heading" data-level="5">Heading 5</h5>
-<h6 class="heading" data-level="6">Heading 6</h6>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Headings</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4">
+    <h1>Heading 1</h1>
+    <h2>Heading 2</h2>
+    <h3>Heading 3</h3>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/atoms/icon/icon.html
+++ b/atoms/icon/icon.html
@@ -1,3 +1,29 @@
-<svg class="icon" width="24" height="24" aria-hidden="true" focusable="false" data-role="icon">
-  <circle cx="12" cy="12" r="10" fill="currentColor" />
-</svg>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Icono</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <span class="icon">★</span>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/atoms/image/image.html
+++ b/atoms/image/image.html
@@ -1,1 +1,29 @@
-<img src="../src/img/v9.6/MacBook.jpeg" alt="" class="responsive-img" data-role="responsive-image" />
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Imagen</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <img src="../../src/img/v9.6/iPhone.jpeg" alt="demo" class="responsive-img">
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/atoms/index.html
+++ b/atoms/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
-  <title>Páginas - AtomOS</title>
+  <title>Átomos - AtomOS</title>
 </head>
 <body>
   <nav class="navbar">
@@ -20,12 +20,15 @@
     </ul>
   </nav>
   <main class="p-4">
-    <h1 class="text-center">Páginas de ejemplo</h1>
+    <h1 class="text-center">Átomos</h1>
     <ul>
-      <li><a href="index.html">Inicio</a></li>
-      <li><a href="contacto.html">Contacto</a></li>
-      <li><a href="quienes-somos.html">Quiénes Somos</a></li>
-      <li><a href="servicios.html">Servicios</a></li>
+      <li><a href="button/button.html">Botón</a></li>
+      <li><a href="headings/headings.html">Headings</a></li>
+      <li><a href="icon/icon.html">Icono</a></li>
+      <li><a href="image/image.html">Imagen</a></li>
+      <li><a href="input-text/input-text.html">Input Text</a></li>
+      <li><a href="label/label.html">Label</a></li>
+      <li><a href="paragraph/paragraph.html">Párrafo</a></li>
     </ul>
   </main>
   <button id="scroll-top">↑</button>

--- a/atoms/input-text/input-text.html
+++ b/atoms/input-text/input-text.html
@@ -1,2 +1,31 @@
-<label for="text" class="visually-hidden">Texto</label>
-<input id="text" class="text-input" type="text" placeholder="Escribe aqui" data-role="input-text" />
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Input Text</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <label for="text" class="visually-hidden">Texto</label>
+    <input id="text" class="text-input" type="text" placeholder="Escribe aquí" data-role="input-text" />
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+  <script src="input-text.js"></script>
+</body>
+</html>
+

--- a/atoms/label/label.html
+++ b/atoms/label/label.html
@@ -1,1 +1,29 @@
-<label class="label" data-role="label">Etiqueta</label>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Label</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <label class="label">Etiqueta de ejemplo</label>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/atoms/paragraph/paragraph.html
+++ b/atoms/paragraph/paragraph.html
@@ -1,1 +1,29 @@
-<p class="paragraph">Lorem ipsum dolor sit amet.</p>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Paragraph</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4">
+    <p class="paragraph">Este es un párrafo de ejemplo con estilo.</p>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
-  <title>Páginas - AtomOS</title>
+  <title>Documentación - AtomOS</title>
 </head>
 <body>
   <nav class="navbar">
@@ -20,12 +20,14 @@
     </ul>
   </nav>
   <main class="p-4">
-    <h1 class="text-center">Páginas de ejemplo</h1>
+    <h1 class="text-center">Documentación</h1>
+    <p>Este sistema sigue la metodología Atomic Design. Encuentra cada nivel en su carpeta correspondiente.</p>
     <ul>
-      <li><a href="index.html">Inicio</a></li>
-      <li><a href="contacto.html">Contacto</a></li>
-      <li><a href="quienes-somos.html">Quiénes Somos</a></li>
-      <li><a href="servicios.html">Servicios</a></li>
+      <li><a href="../atoms/index.html">Átomos</a> – componentes básicos.</li>
+      <li><a href="../molecules/index.html">Moléculas</a> – combinaciones de átomos.</li>
+      <li><a href="../organisms/index.html">Organismos</a> – secciones reutilizables.</li>
+      <li><a href="../templates/index.html">Plantillas</a> – estructuras de página.</li>
+      <li><a href="../pages/index.html">Páginas</a> – ejemplos de uso.</li>
     </ul>
   </main>
   <button id="scroll-top">↑</button>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Importación de estilos AtomOS -->
-    <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="style.css">
     <title>AtomOS</title>
 </head>
 
@@ -16,12 +16,12 @@
             <a href="#" class="nav-logo">AtomOS</a>
             <div class="navbar-toggle">☰</div>
             <ul class="nav-links">
-                <li><a href="#" class="nav-link">Atomos</a></li>
-                <li><a href="#" class="nav-link">Moleculas</a></li>
-                <li><a href="#" class="nav-link">Organismos</a></li>
-                <li><a href="#" class="nav-link">Plantillas</a></li>
-                <li><a href="#" class="nav-link">Páginas</a></li>
-                <li><a href="#" class="nav-link">Documentación</a></li>
+                <li><a href="atoms/index.html" class="nav-link">Átomos</a></li>
+                <li><a href="molecules/index.html" class="nav-link">Moléculas</a></li>
+                <li><a href="organisms/index.html" class="nav-link">Organismos</a></li>
+                <li><a href="templates/index.html" class="nav-link">Plantillas</a></li>
+                <li><a href="pages/index.html" class="nav-link">Páginas</a></li>
+                <li><a href="docs/index.html" class="nav-link">Documentación</a></li>
             </ul>
         </nav>
     </header>
@@ -289,7 +289,8 @@
         </section>
 
     </main>
-    <script type="module" src="js/main.js"></script>
+    <button id="scroll-top">↑</button>
+    <script src="script.js"></script>
 </body>
 
 </html>

--- a/molecules/button-group/button-group.html
+++ b/molecules/button-group/button-group.html
@@ -1,5 +1,33 @@
-<div class="button-group" data-role="button-group">
-  <button class="btn">Uno</button>
-  <button class="btn">Dos</button>
-  <button class="btn">Tres</button>
-</div>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Button Group</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <div class="button-group" data-role="button-group">
+      <button class="btn">Uno</button>
+      <button class="btn">Dos</button>
+      <button class="btn">Tres</button>
+    </div>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/molecules/card/card.html
+++ b/molecules/card/card.html
@@ -1,8 +1,36 @@
-<div class="card" data-role="card">
-  <img src="../src/img/v9.6/iPhone.jpeg" alt="" class="responsive-img">
-  <div class="card-body">
-    <h3 class="card-title">{{title}}</h3>
-    <p class="card-text">{{description}}</p>
-    <button class="btn">{{cta}}</button>
-  </div>
-</div>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Card</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <div class="card" data-role="card">
+      <img src="../../src/img/v9.6/iPhone.jpeg" alt="" class="responsive-img">
+      <div class="card-body">
+        <h3 class="card-title">Título</h3>
+        <p class="card-text">Descripción de la tarjeta.</p>
+        <button class="btn">Acción</button>
+      </div>
+    </div>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/molecules/form-field/form-field.html
+++ b/molecules/form-field/form-field.html
@@ -1,5 +1,33 @@
-<div class="form-field" data-role="form-field">
-  <label class="label" for="field">Nombre</label>
-  <input id="field" class="text-input" type="text" required />
-  <span class="error" hidden>Campo obligatorio</span>
-</div>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Form Field</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4">
+    <div class="form-field" data-role="form-field">
+      <label class="label" for="field">Nombre</label>
+      <input id="field" class="text-input" type="text" required />
+      <span class="error" hidden>Campo obligatorio</span>
+    </div>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/molecules/icon-button/icon-button.html
+++ b/molecules/icon-button/icon-button.html
@@ -1,6 +1,34 @@
-<button class="btn icon-btn" data-role="icon-button">
-  <svg class="icon" width="16" height="16" aria-hidden="true" focusable="false">
-    <circle cx="8" cy="8" r="8" />
-  </svg>
-  <span>Botón</span>
-</button>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Icon Button</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <button class="btn icon-btn" data-role="icon-button">
+      <svg class="icon" width="16" height="16" aria-hidden="true" focusable="false">
+        <circle cx="8" cy="8" r="8" />
+      </svg>
+      <span>Botón</span>
+    </button>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/molecules/icon-list/icon-list.html
+++ b/molecules/icon-list/icon-list.html
@@ -1,5 +1,33 @@
-<ul class="icon-list" data-role="icon-list">
-  <li><span class="icon">✔</span> Elemento 1</li>
-  <li><span class="icon">✔</span> Elemento 2</li>
-  <li><span class="icon">✔</span> Elemento 3</li>
-</ul>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Icon List</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4">
+    <ul class="icon-list" data-role="icon-list">
+      <li><span class="icon">✔</span> Elemento 1</li>
+      <li><span class="icon">✔</span> Elemento 2</li>
+      <li><span class="icon">✔</span> Elemento 3</li>
+    </ul>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/molecules/index.html
+++ b/molecules/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
-  <title>Páginas - AtomOS</title>
+  <title>Moléculas - AtomOS</title>
 </head>
 <body>
   <nav class="navbar">
@@ -20,12 +20,13 @@
     </ul>
   </nav>
   <main class="p-4">
-    <h1 class="text-center">Páginas de ejemplo</h1>
+    <h1 class="text-center">Moléculas</h1>
     <ul>
-      <li><a href="index.html">Inicio</a></li>
-      <li><a href="contacto.html">Contacto</a></li>
-      <li><a href="quienes-somos.html">Quiénes Somos</a></li>
-      <li><a href="servicios.html">Servicios</a></li>
+      <li><a href="button-group/button-group.html">Button Group</a></li>
+      <li><a href="card/card.html">Card</a></li>
+      <li><a href="form-field/form-field.html">Form Field</a></li>
+      <li><a href="icon-button/icon-button.html">Icon Button</a></li>
+      <li><a href="icon-list/icon-list.html">Icon List</a></li>
     </ul>
   </main>
   <button id="scroll-top">↑</button>

--- a/organisms/contact-form/contact-form.html
+++ b/organisms/contact-form/contact-form.html
@@ -1,13 +1,41 @@
-<form class="contact-form" data-role="contact-form">
-  <div class="form-field">
-    <label for="name">Nombre</label>
-    <input id="name" type="text" required>
-    <span class="error" hidden>Requerido</span>
-  </div>
-  <div class="form-field">
-    <label for="email">Email</label>
-    <input id="email" type="email" required>
-    <span class="error" hidden>Email inválido</span>
-  </div>
-  <button class="btn" type="submit">Enviar</button>
-</form>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Contact Form</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4">
+    <form class="contact-form" data-role="contact-form">
+      <div class="form-field">
+        <label for="name">Nombre</label>
+        <input id="name" type="text" required>
+        <span class="error" hidden>Requerido</span>
+      </div>
+      <div class="form-field">
+        <label for="email">Email</label>
+        <input id="email" type="email" required>
+        <span class="error" hidden>Email inválido</span>
+      </div>
+      <button class="btn" type="submit">Enviar</button>
+    </form>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/organisms/footer/footer.html
+++ b/organisms/footer/footer.html
@@ -1,7 +1,35 @@
-<footer class="site-footer" data-role="footer">
-  <div class="section">© 2025 AtomOS</div>
-  <div class="section">
-    <a href="#">Privacidad</a>
-    <a href="#">Términos</a>
-  </div>
-</footer>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Footer</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <footer class="site-footer" data-role="footer">
+      <div class="section">© 2025 AtomOS</div>
+      <div class="section">
+        <a href="#">Privacidad</a>
+        <a href="#">Términos</a>
+      </div>
+    </footer>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/organisms/header/header.html
+++ b/organisms/header/header.html
@@ -1,11 +1,39 @@
-<header class="site-header" data-role="header">
-  <div class="logo">AtomOS</div>
-  <nav class="nav">
-    <ul>
-      <li><a href="index.html">Inicio</a></li>
-      <li><a href="servicios.html">Servicios</a></li>
-      <li><a href="contacto.html">Contacto</a></li>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Header</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
     </ul>
   </nav>
-  <button class="btn">CTA</button>
-</header>
+  <main class="p-4">
+    <header class="site-header" data-role="header">
+      <div class="logo">AtomOS</div>
+      <nav class="nav">
+        <ul>
+          <li><a href="../../pages/index.html">Inicio</a></li>
+          <li><a href="../../pages/servicios.html">Servicios</a></li>
+          <li><a href="../../pages/contacto.html">Contacto</a></li>
+        </ul>
+      </nav>
+      <button class="btn">CTA</button>
+    </header>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/organisms/hero-section/hero-section.html
+++ b/organisms/hero-section/hero-section.html
@@ -1,7 +1,35 @@
-<section class="hero" data-role="hero-section">
-  <div class="hero-content">
-    <h1>{{title}}</h1>
-    <p>{{description}}</p>
-    <button class="btn">{{cta}}</button>
-  </div>
-</section>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Hero Section</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <section class="hero" data-role="hero-section" style="background:#eee;">
+      <div class="hero-content">
+        <h1>Título demo</h1>
+        <p>Descripción de la sección hero.</p>
+        <button class="btn">Llamar</button>
+      </div>
+    </section>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/organisms/index.html
+++ b/organisms/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
-  <title>Páginas - AtomOS</title>
+  <title>Organismos - AtomOS</title>
 </head>
 <body>
   <nav class="navbar">
@@ -20,12 +20,13 @@
     </ul>
   </nav>
   <main class="p-4">
-    <h1 class="text-center">Páginas de ejemplo</h1>
+    <h1 class="text-center">Organismos</h1>
     <ul>
-      <li><a href="index.html">Inicio</a></li>
-      <li><a href="contacto.html">Contacto</a></li>
-      <li><a href="quienes-somos.html">Quiénes Somos</a></li>
-      <li><a href="servicios.html">Servicios</a></li>
+      <li><a href="contact-form/contact-form.html">Contact Form</a></li>
+      <li><a href="footer/footer.html">Footer</a></li>
+      <li><a href="header/header.html">Header</a></li>
+      <li><a href="hero-section/hero-section.html">Hero Section</a></li>
+      <li><a href="testimonial-slider/testimonial-slider.html">Testimonial Slider</a></li>
     </ul>
   </main>
   <button id="scroll-top">↑</button>

--- a/organisms/testimonial-slider/testimonial-slider.html
+++ b/organisms/testimonial-slider/testimonial-slider.html
@@ -1,9 +1,37 @@
-<section class="testimonial-slider" data-role="testimonial-slider">
-  <div class="slides">
-    <blockquote>"Excelente servicio" - Cliente 1</blockquote>
-    <blockquote>"Muy recomendable" - Cliente 2</blockquote>
-    <blockquote>"Volveré a usarlo" - Cliente 3</blockquote>
-  </div>
-  <button class="btn prev">Prev</button>
-  <button class="btn next">Next</button>
-</section>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="../../style.css">
+  <title>Testimonial Slider</title>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="../../index.html" class="nav-logo">AtomOS</a>
+    <div class="navbar-toggle">☰</div>
+    <ul class="nav-links">
+      <li><a href="../../atoms/index.html" class="nav-link">Átomos</a></li>
+      <li><a href="../../molecules/index.html" class="nav-link">Moléculas</a></li>
+      <li><a href="../../organisms/index.html" class="nav-link">Organismos</a></li>
+      <li><a href="../../templates/index.html" class="nav-link">Plantillas</a></li>
+      <li><a href="../../pages/index.html" class="nav-link">Páginas</a></li>
+      <li><a href="../../docs/index.html" class="nav-link">Documentación</a></li>
+    </ul>
+  </nav>
+  <main class="p-4 text-center">
+    <section class="testimonial-slider" data-role="testimonial-slider">
+      <div class="slides">
+        <blockquote>"Excelente servicio" - Cliente 1</blockquote>
+        <blockquote>"Muy recomendable" - Cliente 2</blockquote>
+        <blockquote>"Volveré a usarlo" - Cliente 3</blockquote>
+      </div>
+      <button class="btn prev">Prev</button>
+      <button class="btn next">Next</button>
+    </section>
+  </main>
+  <button id="scroll-top">↑</button>
+  <script src="../../script.js"></script>
+</body>
+</html>
+

--- a/pages/contacto.html
+++ b/pages/contacto.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../style.css">
   <title>Contacto</title>
 </head>
 <body>
@@ -12,6 +12,6 @@
     <!-- include contact-form.html -->
   </main>
   <!-- include footer.html -->
-  <script type="module" src="../js/main.js"></script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/quienes-somos.html
+++ b/pages/quienes-somos.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../style.css">
   <title>Quienes Somos</title>
 </head>
 <body>
@@ -13,6 +13,6 @@
     <p>Texto descriptivo...</p>
   </main>
   <!-- include footer.html -->
-  <script type="module" src="../js/main.js"></script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/pages/servicios.html
+++ b/pages/servicios.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="../css/styles.css">
+  <link rel="stylesheet" href="../style.css">
   <title>Servicios</title>
 </head>
 <body>
@@ -13,6 +13,6 @@
     <p>Descripción de servicios...</p>
   </main>
   <!-- include footer.html -->
-  <script type="module" src="../js/main.js"></script>
+  <script src="../script.js"></script>
 </body>
 </html>

--- a/preview/index.html
+++ b/preview/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
-  <title>Páginas - AtomOS</title>
+  <title>Vista previa - AtomOS</title>
 </head>
 <body>
   <nav class="navbar">
@@ -20,12 +20,12 @@
     </ul>
   </nav>
   <main class="p-4">
-    <h1 class="text-center">Páginas de ejemplo</h1>
+    <h1 class="text-center">Vista previa de componentes</h1>
+    <p>Explora los componentes directamente desde aquí.</p>
     <ul>
-      <li><a href="index.html">Inicio</a></li>
-      <li><a href="contacto.html">Contacto</a></li>
-      <li><a href="quienes-somos.html">Quiénes Somos</a></li>
-      <li><a href="servicios.html">Servicios</a></li>
+      <li><a href="../atoms/button/button.html">Botón</a></li>
+      <li><a href="../molecules/card/card.html">Tarjeta</a></li>
+      <li><a href="../organisms/header/header.html">Header</a></li>
     </ul>
   </main>
   <button id="scroll-top">↑</button>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,32 @@
+// script.js - funcionalidad general para AtomOS
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Alternancia de menú móvil
+  const toggle = document.querySelector('.navbar-toggle');
+  const links = document.querySelector('.nav-links');
+  if (toggle && links) {
+    toggle.addEventListener('click', () => {
+      links.classList.toggle('active');
+    });
+  }
+
+  // Botón scroll al top
+  const topBtn = document.getElementById('scroll-top');
+  if (topBtn) {
+    window.addEventListener('scroll', () => {
+      topBtn.style.display = window.scrollY > 200 ? 'block' : 'none';
+    });
+    topBtn.addEventListener('click', () => {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
+  // Resaltar enlace activo en la navegación
+  const current = window.location.pathname.split('/').pop();
+  document.querySelectorAll('.nav-link').forEach(link => {
+    if (link.getAttribute('href').includes(current) && current !== '') {
+      link.classList.add('active-link');
+    }
+  });
+});
+

--- a/style.css
+++ b/style.css
@@ -1,0 +1,72 @@
+/* style.css - estilos globales y helpers para AtomOS */
+
+/* Variables CSS */
+:root {
+  --color-primary: #007bff;
+  --color-primary-dark: #0056b3;
+  --color-secondary: #6c757d;
+  --color-bg: #ffffff;
+  --font-base: 'Arial', sans-serif;
+  --font-size-base: 16px;
+  --spacing-1: 0.5rem;
+  --spacing-2: 1rem;
+  --spacing-3: 2rem;
+  --radius: 4px;
+}
+
+/* Tipografía y layout */
+body {
+  margin: 0;
+  font-family: var(--font-base);
+  font-size: var(--font-size-base);
+  line-height: 1.5;
+  background: var(--color-bg);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 0;
+}
+
+/* Utilidades */
+.text-center { text-align: center; }
+.text-right { text-align: right; }
+.mt-2 { margin-top: var(--spacing-1); }
+.mt-4 { margin-top: var(--spacing-2); }
+.p-2 { padding: var(--spacing-1); }
+.p-4 { padding: var(--spacing-2); }
+.d-flex { display: flex; }
+.justify-between { justify-content: space-between; }
+
+/* Estilos de navegación */
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-2);
+  background: var(--color-primary-dark);
+  color: #fff;
+}
+.navbar-toggle { display: none; cursor: pointer; }
+.nav-links { display: flex; list-style: none; margin: 0; padding: 0; }
+.nav-link { color: #fff; text-decoration: none; margin-left: var(--spacing-2); }
+.nav-link.active-link { font-weight: bold; }
+
+@media (max-width: 600px) {
+  .navbar-toggle { display: block; }
+  .nav-links { display: none; flex-direction: column; width: 100%; }
+  .nav-links.active { display: flex; }
+}
+
+/* Botón scroll to top */
+#scroll-top {
+  position: fixed;
+  right: var(--spacing-2);
+  bottom: var(--spacing-2);
+  padding: var(--spacing-1) var(--spacing-2);
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: var(--radius);
+  border: none;
+  display: none;
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="../style.css">
-  <title>Páginas - AtomOS</title>
+  <title>Plantillas - AtomOS</title>
 </head>
 <body>
   <nav class="navbar">
@@ -20,12 +20,12 @@
     </ul>
   </nav>
   <main class="p-4">
-    <h1 class="text-center">Páginas de ejemplo</h1>
+    <h1 class="text-center">Plantillas</h1>
     <ul>
-      <li><a href="index.html">Inicio</a></li>
-      <li><a href="contacto.html">Contacto</a></li>
-      <li><a href="quienes-somos.html">Quiénes Somos</a></li>
-      <li><a href="servicios.html">Servicios</a></li>
+      <li><a href="landing.html">Landing</a></li>
+      <li><a href="contact.html">Contacto</a></li>
+      <li><a href="services.html">Servicios</a></li>
+      <li><a href="error404.html">Error 404</a></li>
     </ul>
   </main>
   <button id="scroll-top">↑</button>


### PR DESCRIPTION
## Summary
- add global `style.css` and `script.js`
- create navigation pages for atoms, molecules, organisms, templates and docs
- add demo pages for individual components
- update existing pages to use new assets and relative links
- include GitHub Pages instructions in README
- provide optional preview section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6871ac12e8d48322b9ff673c13311ca6